### PR TITLE
Fix 2 bugs introduced by the slice option

### DIFF
--- a/buildH_calcOP.py
+++ b/buildH_calcOP.py
@@ -1260,6 +1260,8 @@ if __name__ == "__main__":
     else:
         try:
             universe_woH = mda.Universe(args.topfile)
+            begin = 0
+            end = 1
         except:
             raise UserWarning("Can't create MDAnalysis universe with file {}"
                               .format(args.topfile))
@@ -1329,7 +1331,7 @@ if __name__ == "__main__":
 
         # 4) Loop over all frames of the traj *without* H, build Hs and
         # calc OP (ts is a Timestep instance).
-        for ts in universe_woH.trajectory[begin,end]:
+        for ts in universe_woH.trajectory[begin:end]:
             print("Dealing with frame {} at {} ps."
                   .format(ts.frame, universe_woH.trajectory.time))
             # Build H and update their positions in the universe *with* H (in place).


### PR DESCRIPTION
The bugs were :  
- a crash when no xtc was provided due to undefined variables (begin and end)
- a crash when an xtc outputed was specified due to a wrong slice notation (:grimacing:)