### PR TITLE
More tests

### DIFF
--- a/buildh/cli.py
+++ b/buildh/cli.py
@@ -176,57 +176,6 @@ def parse_cli():
     return options, lipids_info
 
 
-def is_allHs_present(def_file, lipids_name, dic_ref_CHnames):
-    """
-    Check if all H's to be rebuild are present in the def file.
-
-    Parameters
-    ----------
-    def_file : str
-        Filename containing OP definition
-        (e.g. `order_parameter_definitions_MODEL_Berger_POPC.def`).
-    lipids_name : dictionnary
-        Comes from dic_lipids.py. Contains carbon names and helper names needed
-        for reconstructing hydrogens.
-    dic_ref_CHnames: dictionnary
-        Contains all CH molecules
-
-    Returns
-    -------
-    boolean
-        whether or not all Hs are present.
-    """
-
-    # check that dic_OP contains all possible C-H pairs.
-    # NOTE The user has to take care that .def file has the right atom names !!!
-    for atname in lipids_name.keys():
-        if atname != "resname":
-            # Check if carbon is present in the definition file.
-            if atname not in dic_ref_CHnames:
-                print("Error: When -opx option is used, the order param "
-                      "definition file (passed with -d arg) must contain "
-                      "all possible carbons on which we want to rebuild "
-                      "hydrogens.")
-                print("Found:", list(dic_ref_CHnames.keys()))
-                print("Needs:", list(lipids_name.keys()))
-                return False
-            # Check that the 3 Hs are in there for that C.
-            nbHs_in_def_file = len(dic_ref_CHnames[atname])
-            tmp_dic = {"CH": 1, "CHdoublebond": 1, "CH2": 2, "CH3": 3}
-            correct_nb_of_Hs = tmp_dic[lipids_name[atname][0]]
-            if  correct_nb_of_Hs != nbHs_in_def_file:
-                print("Error: When -opx option is used, the order param "
-                      "definition file (passed with -d arg) must contain "
-                      "all possible C-H pairs to rebuild.")
-                print("Expected {} hydrogen(s) to rebuild for carbon {}, "
-                      "got {} in definition file {}."
-                      .format(correct_nb_of_Hs, atname,
-                              dic_ref_CHnames[atname], def_file))
-                return False
-
-    return True
-
-
 def main():
     """buildH main function."""
 
@@ -270,7 +219,7 @@ def main():
     #  with arg -d) needs to contain all possible C-H pairs !!!
     if args.opdbxtc:
 
-        if is_allHs_present(args.defop, dic_lipid, dic_Cname2Hnames):
+        if core.is_allHs_present(args.defop, dic_lipid, dic_Cname2Hnames):
             core.gen_XTC_calcOP(args.opdbxtc, universe_woH, dic_OP, dic_lipid,
                                 dic_Cname2Hnames, dic_corresp_numres_index_dic_OP,
                                 begin, end)

--- a/buildh/core.py
+++ b/buildh/core.py
@@ -617,3 +617,54 @@ def gen_XTC_calcOP(basename, universe_woH, dic_OP, dic_lipid,
         newxtc.write(universe_wH)
     # Close xtc.
     newxtc.close()
+
+
+def is_allHs_present(def_file, lipids_name, dic_ref_CHnames):
+    """
+    Check if all H's to be rebuild are present in the def file.
+
+    Parameters
+    ----------
+    def_file : str
+        Filename containing OP definition
+        (e.g. `order_parameter_definitions_MODEL_Berger_POPC.def`).
+    lipids_name : dictionnary
+        Comes from dic_lipids.py. Contains carbon names and helper names needed
+        for reconstructing hydrogens.
+    dic_ref_CHnames: dictionnary
+        Contains all CH molecules
+
+    Returns
+    -------
+    boolean
+        whether or not all Hs are present.
+    """
+
+    # check that dic_ref_CHnames contains all possible C-H pairs.
+    # NOTE The user has to take care that .def file has the right atom names !!!
+    for atname in lipids_name.keys():
+        if atname != "resname":
+            # Check if carbon is present in the definition file.
+            if atname not in dic_ref_CHnames:
+                print("Error: When -opx option is used, the order param "
+                      "definition file (passed with -d arg) must contain "
+                      "all possible carbons on which we want to rebuild "
+                      "hydrogens.")
+                print("Found:", list(dic_ref_CHnames.keys()))
+                print("Needs:", list(lipids_name.keys()))
+                return False
+            # Check that the 3 Hs are in there for that C.
+            nbHs_in_def_file = len(dic_ref_CHnames[atname])
+            tmp_dic = {"CH": 1, "CHdoublebond": 1, "CH2": 2, "CH3": 3}
+            correct_nb_of_Hs = tmp_dic[lipids_name[atname][0]]
+            if  correct_nb_of_Hs != nbHs_in_def_file:
+                print("Error: When -opx option is used, the order param "
+                      "definition file (passed with -d arg) must contain "
+                      "all possible C-H pairs to rebuild.")
+                print("Expected {} hydrogen(s) to rebuild for carbon {}, "
+                      "got {} in definition file {}."
+                      .format(correct_nb_of_Hs, atname,
+                              dic_ref_CHnames[atname], def_file))
+                return False
+
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for buildH_calcOP
+
+Test functions from module cli
+"""
+
+import pathlib
+import pytest
+
+import MDAnalysis as mda
+
+from buildh import cli
+
+dir_data = "test_data"
+path_data = pathlib.Path(__file__).parent / dir_data
+
+# Ignore some MDAnalysis warnings for this test file
+pytestmark = pytest.mark.filterwarnings('ignore::UserWarning')
+
+
+class TestSlice():
+    """
+    Class for testing the slicing options from check_slice_options()
+    This test trajectory contains:
+       - 10 frames
+       - from 0 to 10000 ps
+    """
+
+    def setup_class(self):
+        pdb = path_data / "2POPC.pdb"
+        xtc = path_data / "2POPC.xtc"
+
+        self.universe = mda.Universe(str(pdb), str(xtc))
+
+    # 'begin' and 'end' are in ps.
+    # result_ref is a tuple containing the corresponding frame number for the slice option.
+    @pytest.mark.parametrize('begin, end, result', [
+        (None, None,  (0,11)),
+        (None, 3000,  (0, 4)),
+        (4000, None,  (4, 11)),
+        (6000, 10000, (6,11)),
+        (0,    9501,  (0, 11)),
+        (0,    9499,  (0, 10)),
+        (2501, 3000,  (3,4)),
+        (2499, 3000,  (2,4)),
+        (7501, 7550,  (8,9)),
+    ])
+    def test_correct_slice(self, begin, end, result):
+        """
+        Test with correct values
+        """
+        assert cli.check_slice_options(self.universe, first_frame=begin, last_frame=end) == result
+
+    @pytest.mark.parametrize('begin, end', [
+        (0,     -1000),
+        (-1000, 2000),
+        (400,   20000),
+        (2000,  1000),
+        (11000, 12000),
+    ])
+    def test_wrong_slice(self, begin, end):
+        """
+        Test if the correct exception is raised
+        """
+
+        with pytest.raises(IndexError) as err:
+             cli.check_slice_options(self.universe, first_frame=begin, last_frame=end)
+        assert "Incorrect slice options" in str(err.value)
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -321,3 +321,21 @@ class TestXTCPOPC:
         ref_file_apineiro = path_data / "ref_2POPC_traj.apineiro.out"
         assert filecmp.cmp(test_file_jmelcr, ref_file_jmelcr)
         assert filecmp.cmp(test_file_apineiro, ref_file_apineiro)
+
+
+
+    def test_check_def_file(self):
+        """
+        Test for is_allHs_present()
+        """
+        assert core.is_allHs_present(self.defop, self.dic_lipid, self.dic_Cname2Hnames)
+
+        test_dic = self.dic_Cname2Hnames.copy()
+        # Remove a random carbon
+        del test_dic["C26"]
+        assert not core.is_allHs_present(self.defop, self.dic_lipid, test_dic)
+
+        test_dic2 = self.dic_Cname2Hnames.copy()
+        # Change the number of hydrogens attached to a carbon
+        test_dic2["CA2"] = ('HA21', 'HA22') # should be = ('HA21', 'HA22', 'HA23')
+        assert not core.is_allHs_present(self.defop, self.dic_lipid, test_dic2)


### PR DESCRIPTION
Add tests for cli module (just to the slice function).

I moved the function `is_allHs_present()` to *core* module because I think it belong to this module more than the *cli* one.
This function is called when the user want a trajectory to check if we can rebuild all hydrogens. It's not really related to *cli* module where we just check arguments. 
I add a test too for this one.