### PR TITLE
Add more checks

### DIFF
--- a/buildh/cli.py
+++ b/buildh/cli.py
@@ -110,6 +110,27 @@ def check_slice_options(system, first_frame=None, last_frame=None):
 
     return (number_first_frame, number_last_frame)
 
+def check_lipid_present(universe_woH, lipid_name):
+    """Check if the `lipid_name` residue name is present in `universe_woH`.
+
+    Parameters
+    ----------
+    universe_woH : MDAnalysis universe instance
+        This is the universe *without* hydrogen.
+    lipid_name : str
+        lipid residue name.
+
+    Returns
+    -------
+    Boolean
+        whether or not it's present.
+    """
+    lipid_atoms = universe_woH.select_atoms( f"resname {lipid_name}")
+
+    if len(lipid_atoms) == 0:
+        return False
+    return True
+
 
 def parse_cli():
     """
@@ -217,6 +238,11 @@ def main():
         except:
             raise UserWarning("Can't create MDAnalysis universe with file {}"
                               .format(args.topfile))
+
+    # Check if the lipid name supplied (`lipids_info`) is present in the universe.
+    if not check_lipid_present(universe_woH, dic_lipid['resname']):
+        raise UserWarning(f"No lipid Lipid '{dic_lipid['resname']}' found in {args.topfile}.")
+
     print("System has {} atoms".format(len(universe_woH.coord)))
 
     # 2) Initialize dic for storing OP.

--- a/buildh/lipids.py
+++ b/buildh/lipids.py
@@ -64,3 +64,38 @@ def read_lipids_topH(filenames):
                 lipids_tops[key] = data
 
     return lipids_tops
+
+
+def check_topology(universe, lipid_top):
+    """Check if the topology `lipid_top` is coherent with the structure in `universe`.
+
+    This function check first the lipid residue name then the atoms in the topology.
+    This function return false if there is one missing in the structure.
+    Print also an error message.
+
+    Parameters
+    ----------
+    universe : MDAnalysis universe instance
+    lipid_top : dict
+        lipid topology for hydrogen.
+
+    Returns
+    -------
+    Boolean
+        whether the structure and the topology match
+    """
+    # Check first the lipid residue name
+    resname = lipid_top['resname']
+    lipid_atoms = universe.select_atoms( f"resname {resname}")
+    if len(lipid_atoms) == 0:
+        print(f"No lipid '{resname}' found in the topology.")
+        return False
+
+    # Remove first key 'resname'
+    carbon_atoms = list(lipid_top.keys())[1::]
+    for atom_name in carbon_atoms:
+        if len(universe.select_atoms(f"resname {resname} and name {atom_name}")) == 0:
+            print(f"Atom {atom_name} from topology is not found in your system.")
+            return False
+
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,3 +67,19 @@ class TestSlice():
              cli.check_slice_options(self.universe, first_frame=begin, last_frame=end)
         assert "Incorrect slice options" in str(err.value)
 
+    @pytest.mark.parametrize('lipidname, result', [
+        ("POPC", True),
+        ("POP", False),
+        ("DMPC", False),
+    ])
+    def test_check_lipid_present(self, lipidname, result):
+        """Test for check_lipid_present().
+
+        Parameters
+        ----------
+        lipidname : str
+            lipid name
+        result : Bool
+            Reference result.
+        """
+        assert cli.check_lipid_present(self.universe, lipidname) == result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,19 +67,3 @@ class TestSlice():
              cli.check_slice_options(self.universe, first_frame=begin, last_frame=end)
         assert "Incorrect slice options" in str(err.value)
 
-    @pytest.mark.parametrize('lipidname, result', [
-        ("POPC", True),
-        ("POP", False),
-        ("DMPC", False),
-    ])
-    def test_check_lipid_present(self, lipidname, result):
-        """Test for check_lipid_present().
-
-        Parameters
-        ----------
-        lipidname : str
-            lipid name
-        result : Bool
-            Reference result.
-        """
-        assert cli.check_lipid_present(self.universe, lipidname) == result


### PR DESCRIPTION
I added a couple more checks before proceeding to the rebuild and calculation phase:
 - make sure the topology chosen matches the structure (fix #52)
 - make sure the atoms in def file match the structure.
 - print error messages otherwise.

I'm not sure of the location of the 2 new functions `check_def_file()` and `check_atom`. I think they could belong to a new module call `utils.py` along with `is_allHs_present()` from the core module.

I think also we should get rid of the exception "UserWarning" raised in the `main()` function, they produced 'Traceback' in the terminal when encountered. We could replace them with `sys.exit()`. 

But this is maybe beyond the scope of this PR.