### PR TITLE
Add Read the Docs config file + doc badge

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,28 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+
+conda:
+  environment: binder/environment.yml
+
+# CONDA_USES_MAMBA feature flag uses mamba instead of conda ton install dependencies
+# https://docs.readthedocs.io/en/stable/guides/feature-flags.html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,5 +24,5 @@ python:
 conda:
   environment: binder/environment.yml
 
-# CONDA_USES_MAMBA feature flag uses mamba instead of conda ton install dependencies
+# CONDA_USES_MAMBA feature flag uses mamba instead of conda to install dependencies
 # https://docs.readthedocs.io/en/stable/guides/feature-flags.html

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License: BSD](https://img.shields.io/badge/License-BSD-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/patrickfuchs/buildH/master?urlpath=lab)
+[![Documentation Status](https://readthedocs.org/projects/buildh/badge/?version=latest)](https://buildh.readthedocs.io/en/latest/?badge=latest)
 
 > Build hydrogens from a united-atom MD of lipids and calculate the order parameter.
 


### PR DESCRIPTION
This PR adds Read the Docs configuration file to build documentation.

Conda is used to build the environment. [Documentation](https://docs.readthedocs.io/en/stable/guides/feature-flags.html) explains that mamba can be used to speed up creation of the environment but is not very explicit on how to enable it. Issue #68 has been created to solve this.

We also add the documentation badge in the README.

