### PR TITLE
More explicit message when the parsing of a JSON fails.

### DIFF
--- a/buildh/lipids.py
+++ b/buildh/lipids.py
@@ -46,10 +46,10 @@ def read_lipids_topH(filenames):
             try:
                 topol = json.load(json_file)
             except Exception as e:
-                raise ValueError(f"{filenam_path} is in a bad format.") from e
+                raise ValueError(f"{filenam_path} is in a bad format: " + str(e)) from e
             # make sure at least 'resname' key exists
             if "resname" not in topol:
-                raise ValueError(f"{filenam_path} is in a bad format.")
+                raise ValueError(f"{filenam_path} is in a bad format: keyword 'resname' is missing.")
 
             # Retrieve forcefield and lipid name from the filename
             try:

--- a/tests/test_lipids.py
+++ b/tests/test_lipids.py
@@ -54,4 +54,4 @@ class TestLipids():
         bad_file = "Berger_wrongformat.json"
         with pytest.raises(ValueError) as err:
             lipids.read_lipids_topH([PATH_ROOT_DATA / bad_file])
-        assert f"{bad_file} is in a bad format." in str(err.value)
+        assert f"{bad_file} is in a bad format: keyword 'resname' is missing." in str(err.value)


### PR DESCRIPTION
With this PR, the message is clearer when supplying in wrong JSON file.

For example:

```bash
$ buildH -lt test.json -c docs/Berger_POPC_test_case/start_128popc.pdb  -l Berger_POPC -d def_files/order_parameter_definitions_MODEL_Berger_POPC.def
usage: buildH [-h] -c COORD [-t TRAJ] -l LIPID [-lt LIPID_TOPOLOGY [LIPID_TOPOLOGY ...]] -d DEFOP [-opx OPDBXTC] [-o OUT] [-b BEGIN] [-e END] [-pi PICKLE]
buildH: error: test.json is in a bad format: Expecting property name enclosed in double quotes: line 43 column 3 (char 1330)
```
Fix #78