### PR TITLE
Implement feature to use buildh as a module

### DIFF
--- a/buildh/UI.py
+++ b/buildh/UI.py
@@ -77,8 +77,8 @@ def parse_cli():
     parser.add_argument("-t", "--traj", type=isfile,
                         help="Input trajectory file. Could be in XTC, TRR or DCD format.")
     parser.add_argument("-l", "--lipid", type=str, required=True,
-                        help="Combinaison of the name of the ForceField "
-                        "and the residue name of lipid to calculate the OP on (e.g. Berger_POPC)."
+                        help="Combinaison of ForceField name and residue name "
+                        "for the lipid to calculate the OP on (e.g. Berger_POPC)."
                         "It must match with the internal topology files or the one(s) supplied."
                         "A list of supported terms is printed when calling the help.")
     parser.add_argument("-lt", "--lipid_topology", type=isfile, nargs='+',
@@ -160,29 +160,29 @@ def launch(coord_file, def_file, lipid_type, traj_file=None, out_file="OP_buildH
     def_file : str
         Order parameter definition file.
     lipid_type : str
-        Combinaison of the name of the ForceField and the residue name of lipid to calculate the OP on (e.g. Berger_POPC).
+        Combinaison of ForceField name and residue name for the lipid to calculate the OP on (e.g. Berger_POPC).
         It must match with the internal topology files or the one(s) supplied.
     traj_file : str, optional
-        Trajectory file (could be in XTC, TRR or DCD format.), by default None
+        Trajectory file (could be in XTC, TRR or DCD format), by default None.
     out_file : str, optional
-        Output file name for storing order parameters, by default "OP_buildH.out"
+        Output file name for storing order parameters, by default "OP_buildH.out".
     prefix_traj_ouput : str, optional
         Base name for trajectory output with hydrogens.
-        File extension will be automatically added
-        By default None
+        File extension will be automatically added.
+        By default None.
     begin : int, optional
-        The first frame (ps) to read from the trajectory, by default 0
+        The first frame (ps) to read from the trajectory, by default 0.
     end : int, optional
-        The last frame (ps) to read from the trajectory., by default 1
+        The last frame (ps) to read from the trajectory, by default 1.
     lipid_jsons : list, optional
-        "User topology lipid json file(s), by default None
+        User topology lipid json file(s), by default None.
 
     Raises
     ------
     FileNotFoundError
         When either coord_file, def_file or the traj_file is missing.
     TypeError
-        When lipid_jsons is not a list
+        When lipid_jsons is not a list.
     BuildHError
         When something went wront during calculation.
     """
@@ -243,7 +243,7 @@ def main(coord_file, traj_file, def_file, out_file, prefix_traj_ouput, begin, en
     coord_file : str
         Coordinate file. Only .pdb and .gro files are currently supported.
     traj_file : str
-        Trajectory file (could be in XTC, TRR or DCD format.). Can be None.
+        Trajectory file (could be in XTC, TRR or DCD format). Can be None.
     def_file : str
         Order parameter definition file.
     out_file : str

--- a/buildh/__init__.py
+++ b/buildh/__init__.py
@@ -31,5 +31,5 @@ __version__ = "1.2.0"
 __license__ = "BSD 3-Clause License"
 
 
-from .cli import BuildHError, launch
+from .UI import BuildHError, launch
 

--- a/buildh/__init__.py
+++ b/buildh/__init__.py
@@ -31,4 +31,5 @@ __version__ = "1.2.0"
 __license__ = "BSD 3-Clause License"
 
 
-from . import cli
+from .cli import BuildHError, launch
+

--- a/buildh/cli.py
+++ b/buildh/cli.py
@@ -14,10 +14,10 @@ from . import core
 from . import writers
 from . import utils
 
-# For debugging.
-DEBUG = False
-# For pickling results (useful for future analyses, e.g. drawing distributions).
-PICKLE = False
+
+class BuildHError(Exception):
+    pass
+
 
 def isfile(path):
     """Callback for checking file existence.
@@ -95,7 +95,7 @@ def parse_cli():
     options = parser.parse_args()
 
 
-    # Check topology file extension.
+    # Check coord file extension.
     if not options.coord.endswith("pdb") and not options.coord.endswith("gro"):
         parser.error("Coordinates file must be given in .pdb or .gro format.")
 
@@ -126,42 +126,83 @@ def parse_cli():
     return options, lipids_info
 
 
-def main():
-    """Main function of buildH.
-
-    Correspond to the entry point `buildH`.
-    """
-    # 1) Parse arguments.
+def entry_point():
+    """Correspond to the entry point `buildH`."""
+    # Parse arguments.
     args, dic_lipid = parse_cli()
+
+    try:
+        main(args.coord, args.traj, args.defop, args.out, args.opdbxtc, args.begin, args.end, dic_lipid)
+    except BuildHError as e:
+        sys.exit(e)
+
+
+def launch(coord_file, def_file, lipid_type, traj_file=None, out_file="OP_buildH.out", prefix_traj_ouput=None, begin=0, end=1, lipid_jsons=None):
+
+    # Check files
+    for file in [coord_file, traj_file, def_file]:
+        if file is not None:
+            source = pathlib.Path(file)
+            if not pathlib.Path.is_file(source):
+                raise FileNotFoundError(f"{source} does not exist.")
+
+    # Construct available lipid topologies
+    if lipid_jsons:
+        if not isinstance(lipid_jsons, list):
+            raise TypeError(f"a list is expected for argument 'lipid_jsons'")
+        lipids_files = [pathlib.Path(f) for f in lipid_jsons]
+        # Regenerate lipid topologies dictionary
+        try:
+            lipids_tops = lipids.read_lipids_topH(lipids_files)
+        except ValueError as e:
+            raise BuildHError(e)
+    else:
+        lipids_files = [f for f in lipids.PATH_JSON.iterdir() if f.is_file()]
+        lipids_tops = lipids.read_lipids_topH(lipids_files)
+
+    try:
+        dic_lipid = lipids_tops[lipid_type]
+    except KeyError:
+        raise BuildHError(f"Lipid {lipid_type} is not supported. "
+                               f"List of supported lipids are: " + ", ".join(lipids_tops.keys()))
+
+
+    try:
+        main(coord_file, traj_file, def_file, out_file, prefix_traj_ouput, begin, end, dic_lipid)
+    except BuildHError as e:
+        raise e
+
+
+def main(coord_file, traj_file, def_file, out_file, prefix_traj_ouput, begin, end, dic_lipid):
 
     # 2) Create universe without H.
     print("Constructing the system...")
-    if args.traj:
+    if traj_file:
         try:
-            universe_woH = mda.Universe(args.coord, args.traj)
-            begin, end = utils.check_slice_options(universe_woH, args.begin, args.end)
+            universe_woH = mda.Universe(coord_file, traj_file)
+            begin, end = utils.check_slice_options(universe_woH, begin, end)
             traj_file = True
         except IndexError:
-            sys.exit("Slicing options are not correct.")
+            raise BuildHError("Slicing options are not correct.")
         except:
-            sys.exit(f"Can't create MDAnalysis universe with files {args.coord} and {args.traj}.")
+            raise BuildHError(f"Can't create MDAnalysis universe with files {coord_file} and {traj_file}.")
     else:
         try:
-            universe_woH = mda.Universe(args.coord)
+            universe_woH = mda.Universe(coord_file)
             begin = 0
             end = 1
             traj_file = False
         except:
-            sys.exit(f"Can't create MDAnalysis universe with file {args.coord}.")
+            raise BuildHError(f"Can't create MDAnalysis universe with file {coord_file}.")
 
 
     # 2) Initialize dic for storing OP.
     # Init dic of correspondance : {('C1', 'H11'): 'gamma1_1',
     # {('C1', 'H11'): 'gamma1_1', ...}.
     try:
-        dic_atname2genericname = init_dics.make_dic_atname2genericname(args.defop)
+        dic_atname2genericname = init_dics.make_dic_atname2genericname(def_file)
     except ValueError as e:
-        sys.exit(e)
+        raise BuildHError(e)
     # Initialize dic_OP (see function init_dic_OP() for the format).
     dic_OP, dic_corresp_numres_index_dic_OP = init_dics.init_dic_OP(universe_woH,
                                                                     dic_atname2genericname,
@@ -175,16 +216,16 @@ def main():
 
     # Check if the lipid topology match the the structure.
     if not lipids.check_topology(universe_woH, dic_lipid):
-        sys.exit(f"The topology chosen does not match the structure provided in {args.coord}")
+        raise BuildHError(f"The topology chosen does not match the structure provided in {coord_file}")
 
     # Check if atoms name in the def file are present in the structure.
     atoms_name = [heavy_atom for (heavy_atom, _) in dic_atname2genericname.keys()]
     if not utils.check_def_file(universe_woH, dic_lipid['resname'], atoms_name):
-        sys.exit(f"Atoms defined in {args.defop} are missing in the structure {args.coord}.")
+        raise BuildHError(f"Atoms defined in {def_file} are missing in the structure {coord_file}.")
 
     # Check the def file and the topology are coherent.
     if not utils.check_def_topol_consistency(dic_Cname2Hnames, dic_lipid):
-        sys.exit(f"Atoms defined in {args.defop} are not consistent with topology chosen.")
+        raise BuildHError(f"Atoms defined in {def_file} are not consistent with topology chosen.")
 
 
     print("System has {} atoms".format(len(universe_woH.coord)))
@@ -192,35 +233,25 @@ def main():
     # If traj output files are requested.
     # NOTE Here, we need to reconstruct all Hs. Thus the op definition file (passed
     #  with arg -d) needs to contain all possible C-H pairs !!!
-    if args.opdbxtc:
+    if prefix_traj_ouput:
 
-        if utils.is_allHs_present(args.defop, dic_lipid, dic_Cname2Hnames):
-            core.gen_coordinates_calcOP(args.opdbxtc, universe_woH, dic_OP, dic_lipid,
+        if utils.is_allHs_present(def_file, dic_lipid, dic_Cname2Hnames):
+            core.gen_coordinates_calcOP(prefix_traj_ouput, universe_woH, dic_OP, dic_lipid,
                                         dic_Cname2Hnames, dic_corresp_numres_index_dic_OP,
                                         begin, end, traj_file)
         else:
-            sys.exit(f"Error on the number of H's to rebuild. An output trajectory has been "
-                     f"requestest but {args.defop} doesn't contain all hydrogens to rebuild.")
+            raise BuildHError(f"Error on the number of H's to rebuild. An output trajectory has been "
+                     f"requestest but {def_file} doesn't contain all hydrogens to rebuild.")
 
     # 6) If no traj output file requested, use fast indexing to speed up OP
     # calculation. The function fast_build_all_Hs() returns nothing, dic_OP
     # is modified in place.
-    if not args.opdbxtc:
+    if not prefix_traj_ouput:
         core.fast_build_all_Hs_calc_OP(universe_woH, begin, end, dic_OP,
                                        dic_lipid, dic_Cname2Hnames)
 
 
     # Output to a file.
-    writers.write_OP(args.out, dic_atname2genericname,
+    writers.write_OP(out_file, dic_atname2genericname,
                             dic_OP, dic_lipid['resname'])
-    print(f"Results written to {args.out}")
-
-    # Pickle results
-    if args.pickle:
-        with open(args.pickle, "wb") as f:
-            # Pickle the dic using the highest protocol available.
-            pickle.dump(dic_OP, f, pickle.HIGHEST_PROTOCOL)
-            print("dictionary pickled and written to {}".format(args.pickle))
-        #  To unpickle
-        #with open("OP.pickle", "rb") as f:
-        #    dic_OP = pickle.load(f)
+    print(f"Results written to {out_file}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,4 +42,4 @@ test =
 
 [options.entry_points]
 console_scripts =
-    buildH = buildh.cli:main
+    buildH = buildh.cli:entry_point


### PR DESCRIPTION
This a first test to try to use buildH as a module, as suggested in #77 

I tried to minimize the code modifications.
I created a new `launch()` function in the  `cli` module which will be called when using buildH as a module.
I splitted the old `main` function to separate the CLI management from the rest.
There is no more `sys.exit()` in the `main` function in order to avoid exiting Python when using buildH as a module. Instead a custom exception `BuildHError` is thrown. Either it's catch by the entry point and a `sys.exit()` is called either it's the duty of script to call `buildh.launch()` to catch it.

I think also the `cli` module should be renamed `ui` (for User Interface) since the `launch()` function is inside.

A simple call to `buildh.launch()` will looks like that:
```python
import buildh

buildh.launch("docs/Berger_POPC_test_case/start_128popc.pdb", "def_files/order_parameter_definitions_MODEL_Berger_POPC.def", "Berger_POPC")
```
What do you think?
Once we all agree, I'll create the docstrings.
