### PR TITLE
Fix setup.cfg to include json files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 **Dev**
 
+- Fix setup.cfg to include json files in python package archive
+
 **1.3.0**
 
 - Complete documentation

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ install_requires =
     pandas
     MDAnalysis
     numba
-include_package_data = True
 
 [options.package_data]
 * = LICENSE.txt, CHANGELOG.md


### PR DESCRIPTION
in setup.[cfg,py], options `include_package_data` and `package_data` are mutually exclusive (https://setuptools.readthedocs.io/en/latest/userguide/datafiles.html). For our case, we just need `package_data` options.

fix #103