### PR TITLE
Fix xtc writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 **Dev**
 
-- Add support for: CHARMM36UA DPPC 
+- Write box dimensions in the requested trajectory output
+- Fix write duplicate 1st frame when requestest a trajectory output
+- Add support for: CHARMM36UA DPPC
 - Limit Python version >= 3.6 <=3.8 (for MDanalysis compatibility)
 - Add support for: Berger DOPC/DPPC/POPS, GROMOS-CKP POPC/POPS, GROMOS-53A6L DPPC
 

--- a/buildh/core.py
+++ b/buildh/core.py
@@ -631,8 +631,6 @@ def gen_coordinates_calcOP(basename, universe_woH, dic_OP, dic_lipid,
         # Create an xtc writer.
         print("Writing trajectory with hydrogens in xtc file.")
         newxtc = XTC.XTCWriter(xtcout_filename, len(universe_wH.atoms))
-        # Write 1st frame.
-        newxtc.write(universe_wH)
 
         # 4) Loop over all frames of the traj *without* H, build Hs and
         # calc OP (ts is a Timestep instance).

--- a/buildh/core.py
+++ b/buildh/core.py
@@ -645,6 +645,8 @@ def gen_coordinates_calcOP(basename, universe_woH, dic_OP, dic_lipid,
             build_all_Hs_calc_OP(universe_woH, ts, dic_lipid, dic_Cname2Hnames,
                                 universe_wH, dic_OP, dic_corresp_numres_index_dic_OP,
                                 dic_lipids_with_indexes)
+            # Update the box values into the new Universe
+            universe_wH.trajectory[0].dimensions = ts.dimensions
             # Write new frame to xtc.
             newxtc.write(universe_wH)
         # Close xtc.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,11 +4,12 @@ Unit tests for buildH_calcOP.
 Test functions from module core
 """
 
+import os
 import pathlib
 import pytest
 
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_equal
 import MDAnalysis as mda
 import pandas as pd
 
@@ -354,3 +355,26 @@ class TestXTCPOPC:
         for (key), value in self.ref_OP.items():
             assert key in self.dic_OP.keys()
             assert_almost_equal(self.dic_OP[key], value)
+
+
+    def test_output_traj(self, tmp_path):
+        """Test the validity of the ouput trajectory files when requested
+
+        Parameters
+        ----------
+        tmp_path: function
+            pytest callback which return a unique directory.
+        """
+
+        os.chdir(tmp_path)
+        core.gen_coordinates_calcOP("test", self.universe_woH, self.dic_OP, self.dic_lipid,
+                                    self.dic_Cname2Hnames, self.dic_corresp_numres_index_dic_OP,
+                                    self.begin, self.end, True)
+
+        #Tests macro values of the output files
+        u = mda.Universe("test.pdb", "test.xtc")
+        assert_equal(u.trajectory.n_frames, 11)
+        assert_equal(u.atoms.n_atoms, 268)
+        assert_almost_equal(u.trajectory[4].dimensions,
+                            np.array([66.251070, 66.25107, 88.025925, 90.0, 90.0, 90.0], dtype=np.float32))
+


### PR DESCRIPTION
This PR fix 2 issues:

  - a duplicate write of the 1st frame of XTC when requested an output trajectory with H (first commit)
  - write the box dimensions of each frame (retrieve from the read XTC) in the output trajectory