### PR TITLE
Add feature to ignore CH3 groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 **Dev**
 
+- Add option to ignore CH pairs when they belongs to a CH3 group.
+
 **1.6.0**
 
 - Avoid output trajectory rewind when writing box dimensions

--- a/buildh/UI.py
+++ b/buildh/UI.py
@@ -274,6 +274,11 @@ def main(coord_file, traj_file, def_file, out_file, prefix_traj_ouput, dic_lipid
     BuildHError
         When something went wront during calculation.
     """
+
+    if ignore_CH3s and prefix_traj_ouput:
+        raise BuildHError("An output trajectory can't be requested when the option to ignore CH3s groups is activated "
+                          "since all hydrogens are needed to rebuild a trajectory.")
+
     # Create universe without H.
     print("Constructing the system...")
     if traj_file:

--- a/buildh/UI.py
+++ b/buildh/UI.py
@@ -101,7 +101,7 @@ def parse_cli():
                         help="The first frame (ps) to read from the trajectory.")
     parser.add_argument("-e", "--end", type=int,
                         help="The last frame (ps) to read from the trajectory.")
-    parser.add_argument("-ich", "--ignore-CH3s", action='store_true',
+    parser.add_argument("-igch3", "--ignore-CH3s", action='store_true',
                         help="Ignore CH3s groups for the construction of hydrogens "
                              "and the calculation of the OP.")
     # parser.add_argument("-pi", "--pickle", type=str,

--- a/tests/test_UI.py
+++ b/tests/test_UI.py
@@ -230,6 +230,15 @@ class TestCLI:
         assert err.type == SystemExit
         assert "Slicing is only possible with a trajectory file." in capsys.readouterr().err
 
+    def test_fails_CLI_igCH3_opx(self, capsys):
+        """Fail tests when passing both -igch3 and -opx flag"""
+        sys.argv = (self.common_args + ["-l", "Berger_POPC"]
+                    + ["--ignore-CH3s"] + ["-opx", "base"])
+        with pytest.raises(SystemExit) as err:
+            UI.entry_point()
+        assert err.type == SystemExit
+        assert "An output trajectory can't be requested" in str(err.value)
+
 
 # Move to a temporary directory because some output files are written in the current directory.
 @pytest.mark.usefixtures("cd_tmp_dir")
@@ -264,7 +273,7 @@ class TestLaunch:
         assert "Results written to OP_buildH.out" in captured
 
 
-    def test_launch_minimal(self, capsys):
+    def test_launch_igCH3s(self, capsys):
         """Test launch with ignore_CH3s flag"""
         args = self.args.copy()
         args["ignore_CH3s"] = True
@@ -327,3 +336,14 @@ class TestLaunch:
             UI.launch(**args)
         assert err.type == BuildHError
         assert "Lipid PPHA is not supported" in str(err.value)
+
+
+    def test_fails_igCH3_opx(self, capsys):
+        """Fail tests when passing both -igch3 and -opx flag"""
+        args = self.args.copy()
+        args["ignore_CH3s"] = True
+        args["prefix_traj_ouput"] = "basename"
+        with pytest.raises(BuildHError) as err:
+            UI.launch(**args)
+        assert err.type == BuildHError
+        assert "An output trajectory can't be requested" in str(err.value)

--- a/tests/test_UI.py
+++ b/tests/test_UI.py
@@ -42,7 +42,8 @@ class TestMain:
         "prefix_traj_ouput" : None,
         "begin"             : None,
         "end"               : None,
-        "dic_lipid"         : None
+        "dic_lipid"         : None,
+        "ignore_CH3s"       : False
     }
 
     # Default output used for assessement
@@ -70,6 +71,14 @@ class TestMain:
         UI.main(**args)
         captured = capsys.readouterr().out
         assert "Results written to text.txt" in captured
+
+    def test_main_ignCH3(self, capsys):
+        """Test main with flag ignore-CH3s activated."""
+        args = self.args.copy()
+        args["ignore_CH3s"] = True
+        UI.main(**args)
+        captured = capsys.readouterr().out
+        assert "(--ignore-CH3s activated)" in captured
 
 
     def test_main_subdef(self, capsys):
@@ -171,6 +180,15 @@ class TestCLI:
         captured = capsys.readouterr().out
         assert "Results written to OP_buildH.out" in captured
 
+    def test_CLI_ignCH3s(self, capsys):
+        """Test working CLI with minimal arguments."""
+        sys.argv = (self.common_args + ["-l", "Berger_POPC"]
+                    + ["--ignore-CH3s"])
+        UI.entry_point()
+        captured = capsys.readouterr().out
+        assert "(--ignore-CH3s activated)" in captured
+        assert "Results written to OP_buildH.out" in captured
+
 
     def test_CLI_traj(self, capsys):
         """Test working CLI with all trajectory arguments."""
@@ -231,7 +249,8 @@ class TestLaunch:
         "prefix_traj_ouput" : None,
         "begin"             : None,
         "end"               : None,
-        "lipid_jsons"       : None
+        "lipid_jsons"       : None,
+        "ignore_CH3s"       : False,
     }
 
     # Default output used for assessement
@@ -243,6 +262,17 @@ class TestLaunch:
         UI.launch(**self.args)
         captured = capsys.readouterr().out
         assert "Results written to OP_buildH.out" in captured
+
+
+    def test_launch_minimal(self, capsys):
+        """Test launch with ignore_CH3s flag"""
+        args = self.args.copy()
+        args["ignore_CH3s"] = True
+        UI.launch(**args)
+        captured = capsys.readouterr().out
+        assert "Results written to OP_buildH.out" in captured
+        assert "(--ignore-CH3s activated)" in captured
+
 
     def test_launch_traj(self, capsys):
         """Test launch with all trajectory arguments."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -181,7 +181,7 @@ class TestPDBPOPC:
 
         # Check statistics
         assert_almost_equal(np.mean(self.dic_OP[('C40', 'H401')]), -0.28794656)
-        assert_almost_equal(np.mean(self.dic_OP[('C17', 'H171')]), -0.18843357)
+        assert_almost_equal(np.mean(self.dic_OP[('C17', 'H171')]), -0.1884334)
 
         # Check few particular cases
         # Use of a loop to check key and value separately.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -58,13 +58,15 @@ class TestPDBPOPC:
         self.dic_lipid = lipids_tops["Berger_POPC"]
         self.begin = 0
         self.end = 1
+        self.ignore_CH3s = False
 
         # intern attributes
         self.universe_woH = mda.Universe(str(self.pdb))
         self.dic_atname2genericname = init_dics.make_dic_atname2genericname(self.defop)
         self.dic_OP, self.dic_corresp_numres_index_dic_OP = init_dics.init_dic_OP(self.universe_woH,
                                                                                   self.dic_atname2genericname,
-                                                                                  self.dic_lipid['resname'])
+                                                                                  self.dic_lipid,
+                                                                                  self.ignore_CH3s)
         self.dic_Cname2Hnames = init_dics.make_dic_Cname2Hnames(self.dic_OP)
 
 
@@ -77,7 +79,8 @@ class TestPDBPOPC:
         """
         self.dic_OP, self.dic_corresp_numres_index_dic_OP = init_dics.init_dic_OP(self.universe_woH,
                                                                                   self.dic_atname2genericname,
-                                                                                  self.dic_lipid['resname'])
+                                                                                  self.dic_lipid,
+                                                                                  self.ignore_CH3s)
 
 
     @pytest.mark.parametrize('atom_index, Hs_coords', [
@@ -294,13 +297,15 @@ class TestXTCPOPC:
         self.dic_lipid = lipids_tops["Berger_POPC"]
         self.begin = 0
         self.end = 11
+        self.ignore_CH3s = False
 
         # attributes
         self.universe_woH = mda.Universe(str(self.pdb), str(self.xtc))
         self.dic_atname2genericname = init_dics.make_dic_atname2genericname(self.defop)
         self.dic_OP, self.dic_corresp_numres_index_dic_OP = init_dics.init_dic_OP(self.universe_woH,
                                                                                   self.dic_atname2genericname,
-                                                                                  self.dic_lipid['resname'])
+                                                                                  self.dic_lipid,
+                                                                                  self.ignore_CH3s)
         self.dic_Cname2Hnames = init_dics.make_dic_Cname2Hnames(self.dic_OP)
 
     # Method called before each test method.
@@ -312,7 +317,8 @@ class TestXTCPOPC:
         """
         self.dic_OP, self.dic_corresp_numres_index_dic_OP = init_dics.init_dic_OP(self.universe_woH,
                                                                                   self.dic_atname2genericname,
-                                                                                  self.dic_lipid['resname'])
+                                                                                  self.dic_lipid,
+                                                                                  self.ignore_CH3s)
 
     def test_fast_calcOP(self):
         """Test fast_build_all_Hs_calc_OP() on a trajectory.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -168,7 +168,8 @@ class TestDef:
         self.dic_atname2genericname = init_dics.make_dic_atname2genericname(def_file)
         self.dic_OP, self.dic_corresp_numres_index_dic_OP = init_dics.init_dic_OP(self.universe_woH,
                                                                                   self.dic_atname2genericname,
-                                                                                  self.dic_lipid['resname'])
+                                                                                  self.dic_lipid,
+                                                                                  self.ignore_CH3s)
         self.dic_Cname2Hnames = init_dics.make_dic_Cname2Hnames(self.dic_OP)
 
 
@@ -181,6 +182,7 @@ class TestDef:
         self.pdb = self.PATH_DATA / "2POPC.pdb"
         self.defop = self.PATH_DATA / "OP_def_BergerPOPC.def"
         self.dic_lipid = lipids_tops["Berger_POPC"]
+        self.ignore_CH3s = False
 
         # attributes
         self.universe_woH = mda.Universe(str(self.pdb))
@@ -188,7 +190,8 @@ class TestDef:
         self.dic_atname2genericname = init_dics.make_dic_atname2genericname(self.defop)
         self.dic_OP, self.dic_corresp_numres_index_dic_OP = init_dics.init_dic_OP(self.universe_woH,
                                                                                   self.dic_atname2genericname,
-                                                                                  self.dic_lipid['resname'])
+                                                                                  self.dic_lipid,
+                                                                                  self.ignore_CH3s)
         self.dic_Cname2Hnames = init_dics.make_dic_Cname2Hnames(self.dic_OP)
 
 

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -57,13 +57,15 @@ class TestWriters():
 
         self.begin = 0
         self.end = 1
+        self.ignore_CH3s = False
 
         # attributes
         self.universe_woH = mda.Universe(str(self.pdb))
         self.dic_atname2genericname = init_dics.make_dic_atname2genericname(self.defop)
         self.dic_OP, self.dic_corresp_numres_index_dic_OP = init_dics.init_dic_OP(self.universe_woH,
                                                                                   self.dic_atname2genericname,
-                                                                                  self.dic_lipid['resname'])
+                                                                                  self.dic_lipid,
+                                                                                  self.ignore_CH3s)
         self.dic_Cname2Hnames = init_dics.make_dic_Cname2Hnames(self.dic_OP)
 
         # Compute the order parameter


### PR DESCRIPTION
This follow discussion in #157 

The option is called ``--ignore-CH3s``.
When activated, hydrogens from CH3 groups aren't built and Order Parameters of CH pairs belonging to the group aren't computed either.

The easiest way was to modify `init_dic_OP()` to remove keys which belongs to CH3 groups (both from the `dic_OP` and `dic_atname2genericname` dictionaries.)

- [ ] Add small text in the doc